### PR TITLE
Update Wifi.c

### DIFF
--- a/co2_sensor/src/Wifi.c
+++ b/co2_sensor/src/Wifi.c
@@ -131,8 +131,8 @@ void append_uint16(uint16_t *b, size_t size, char *msg_ptr, const char *type)
     time_t now = time(NULL);
 
     // measurement type header
-    int msgSize = variable_sprintf_size(meas_str, 3, type, now, (SCD41_SAMPLE_INTERVAL * 1000));
-    snprintf(temp, msgSize, meas_str, type, now, (SCD41_SAMPLE_INTERVAL * 1000));
+    int msgSize = variable_sprintf_size(meas_str, 3, type, now, (SCD41_SAMPLE_INTERVAL));
+    snprintf(temp, msgSize, meas_str, type, now, (SCD41_SAMPLE_INTERVAL));
     strcat(msg_ptr, temp);
 
     // append measurements


### PR DESCRIPTION
interval in [POST /device/measurements/fixed-interval](https://api.tst.energietransitiewindesheim.nl/docs#/default/device_upload_fixed_device_measurements_fixed_interval_post) is defined seconds (NOT milliseconds)