### PR TITLE
Feat: SCD41 configuration

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -47,6 +47,8 @@ build_flags =
     -DCONFIG_TWOMES_TEST_SERVER         ;line uncommented = use test server; line commented = use other server
 ;   -DCONFIG_TWOMES_PRODUCTION_SERVER   ;line uncommented = use production server; line commented = use other server
 ;   -DCONFIG_TWOMES_OTA_FIRMWARE_UPDATE ;line commented = disabled; line uncommented = enabled
+;   -DCONFIG_TWOMES_SCD41_PROTO_HAT     ;line commented = disabled; line uncommented = use SCD41 in proto HAT
+    -DCONFIG_TWOMES_SCD41_CO2L          ;line commented = disabled; line uncommented = use SCD41 in M5STACK CO2L
     -D"$PIOENV"
 
 ;monitor settings:

--- a/src/i2c_hal_port_1.c
+++ b/src/i2c_hal_port_1.c
@@ -5,14 +5,22 @@
 #define LOG_LOCAL_LEVEL ESP_LOG_NONE
 #include <esp_log.h>
 
+#if defined CONFIG_TWOMES_SCD41_PROTO_HAT
+#define SCD41_GPIO_SDA GPIO_NUM_25
+#define SCD41_GPIO_SCL GPIO_NUM_26
+#elif defined CONFIG_TWOMES_SCD41_CO2L
+#define SCD41_GPIO_SDA GPIO_NUM_32
+#define SCD41_GPIO_SCL GPIO_NUM_33
+#endif
+
 void i2c_hal_init_port_1() {
     // config
     i2c_config_t config =
     {
         .mode = I2C_MODE_MASTER,
-        .sda_io_num = GPIO_NUM_25,
+        .sda_io_num = SCD41_GPIO_SDA,
         .sda_pullup_en = GPIO_PULLUP_ENABLE,
-        .scl_io_num = GPIO_NUM_26,
+        .scl_io_num = SCD41_GPIO_SCL,
         .scl_pullup_en = GPIO_PULLUP_ENABLE,
         .master.clk_speed = 40000L
     };

--- a/src/scd41.c
+++ b/src/scd41.c
@@ -144,7 +144,12 @@ esp_err_t co2_force_recalibration(uint8_t address, int16_t* offset)
 	for (int i = 0; i < 36; i++)
 	{
 		uint16_t values[3];
-		co2_read(address, values);
+		esp_err_t err = co2_read(address, values);
+		if (err != ESP_OK)
+		{
+			ESP_LOGW("CO2", "CRC was incorrect or no sensor wat attached.");
+			return ESP_ERR_INVALID_RESPONSE;
+		}
 	}
 
 	// Generate command buffer:


### PR DESCRIPTION
This change allows configuration of the SCD41. You can select in the platormio.ini if it is connected with a proto HAT or as a CO2L.